### PR TITLE
Fix README capitalization

### DIFF
--- a/store/hbase/README.md
+++ b/store/hbase/README.md
@@ -6,7 +6,7 @@ Learn more about the storage layout by reading [the storage description](documen
 
 ## Getting Started
 
-To get started with the Maryk Hbase Store, simply use the following code snippet. Be sure to pass a valid HBase connection.
+To get started with the Maryk HBase Store, simply use the following code snippet. Be sure to pass a valid HBase connection.
 
 You can also optionally pass a namespace to the store if you want to use a specific HBase namespace.
 


### PR DESCRIPTION
## Summary
- fix casing in the HBase README

## Testing
- `./gradlew test --dry-run` *(fails: Could not resolve all dependencies for configuration 'classpath'.)*

------
https://chatgpt.com/codex/tasks/task_e_683f5718d16883218f673d3827f851b2