### PR TITLE
Fix terminal client rendering and RocksDB wiring

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,4 +46,5 @@ include(
     ":store:memory",
     ":store:rocksdb",
     ":store:foundationdb",
+    ":store:terminal",
 )

--- a/store/terminal/build.gradle.kts
+++ b/store/terminal/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("maryk.conventions.kotlin-jvm")
+    kotlin("plugin.compose")
+}
+
+dependencies {
+    implementation(projects.core)
+    implementation(projects.store.shared)
+    implementation(projects.store.rocksdb)
+    implementation(projects.store.foundationdb)
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:_")
+    implementation("com.jakewharton.mosaic:mosaic-runtime:_")
+    implementation("org.jetbrains.compose.runtime:runtime:_")
+    implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:_")
+    implementation("org.foundationdb:fdb-java:_")
+    implementation("org.rocksdb:rocksdbjni:_")
+}

--- a/store/terminal/build.gradle.kts
+++ b/store/terminal/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("maryk.conventions.kotlin-jvm")
     kotlin("plugin.compose")
+    application
 }
 
 dependencies {
@@ -15,4 +16,8 @@ dependencies {
     implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:_")
     implementation("org.foundationdb:fdb-java:_")
     implementation("org.rocksdb:rocksdbjni:_")
+}
+
+application {
+    mainClass.set("maryk.datastore.terminal.TerminalClientKt")
 }

--- a/store/terminal/build.gradle.kts
+++ b/store/terminal/build.gradle.kts
@@ -10,12 +10,9 @@ dependencies {
     implementation(projects.store.rocksdb)
     implementation(projects.store.foundationdb)
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:_")
     implementation("com.jakewharton.mosaic:mosaic-runtime:_")
     implementation("org.jetbrains.compose.runtime:runtime:_")
     implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:_")
-    implementation("org.foundationdb:fdb-java:_")
-    implementation("org.rocksdb:rocksdbjni:_")
 }
 
 application {

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/ModelRenderer.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/ModelRenderer.kt
@@ -24,7 +24,7 @@ fun renderModelDefinition(model: StoredModel): List<String> {
     val meta = model.definition.Meta
     lines += "  Key definition: ${meta.keyDefinition::class.simpleName ?: meta.keyDefinition}".trimEnd()
     meta.indexes?.takeIf { it.isNotEmpty() }?.let { indexes ->
-        lines += "  Indexes:" 
+        lines += "  Indexes:"
         indexes.forEach { index -> lines += "    - $index" }
     }
     meta.reservedNames?.takeIf { it.isNotEmpty() }?.let { names ->
@@ -129,9 +129,7 @@ private fun collectAttributes(definition: IsPropertyDefinition<*>): List<String>
         is EnumDefinition<*> -> {
             attributes += "enum: ${definition.enum.name}"
             @Suppress("UNCHECKED_CAST")
-            val cases = definition.enum.cases()
-                .map { enumCase -> (enumCase as IndexedEnum).name }
-                .joinToString()
+            val cases = definition.enum.cases().joinToString { enumCase -> (enumCase as IndexedEnum).name }
             if (cases.isNotBlank()) {
                 attributes += "cases: $cases"
             }

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/ModelRenderer.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/ModelRenderer.kt
@@ -1,0 +1,89 @@
+package maryk.datastore.terminal
+
+import maryk.core.properties.definitions.IsEmbeddedDefinition
+import maryk.core.properties.definitions.IsListDefinition
+import maryk.core.properties.definitions.IsMapDefinition
+import maryk.core.properties.definitions.IsSetDefinition
+import maryk.core.properties.IsPropertyContext
+import maryk.core.properties.definitions.wrapper.IsDefinitionWrapper
+import maryk.datastore.terminal.driver.StoredModel
+
+fun renderModelDefinition(model: StoredModel): List<String> {
+    val lines = mutableListOf<String>()
+    lines += "Model ${model.name} (version ${model.version})"
+    val meta = model.definition.Meta
+    lines += "  Key definition: ${meta.keyDefinition::class.simpleName ?: meta.keyDefinition}".trimEnd()
+    meta.indexes?.takeIf { it.isNotEmpty() }?.let { indexes ->
+        lines += "  Indexes:" 
+        indexes.forEach { index -> lines += "    - $index" }
+    }
+    meta.reservedNames?.takeIf { it.isNotEmpty() }?.let { names ->
+        lines += "  Reserved names: ${names.joinToString()}"
+    }
+    meta.reservedIndices?.takeIf { it.isNotEmpty() }?.let { indices ->
+        lines += "  Reserved indices: ${indices.joinToString()}"
+    }
+    lines += "  Properties:"
+    if (!model.definition.iterator().hasNext()) {
+        lines += "    <none>"
+    } else {
+        for (property in model.definition) {
+            lines.addAll(describeProperty(property, "    "))
+        }
+    }
+    return lines
+}
+
+private fun describeProperty(
+    wrapper: IsDefinitionWrapper<*, *, IsPropertyContext, *>,
+    indent: String,
+): List<String> {
+    val definition = wrapper.definition
+    val details = buildString {
+        append(indent)
+        append("- ")
+        append(wrapper.index)
+        append(": ")
+        append(wrapper.name)
+        append(" (")
+        append(definition::class.simpleName ?: definition::class.qualifiedName)
+        append(')')
+        val flags = mutableListOf<String>()
+        if (definition.required) flags += "required"
+        if (definition.final) flags += "final"
+        if (flags.isNotEmpty()) {
+            append(" [")
+            append(flags.joinToString(", "))
+            append(']')
+        }
+        when (definition) {
+            is IsListDefinition<*, *> -> {
+                append(" element=")
+                append(definition.valueDefinition::class.simpleName ?: definition.valueDefinition::class.qualifiedName)
+            }
+            is IsSetDefinition<*, *> -> {
+                append(" element=")
+                append(definition.valueDefinition::class.simpleName ?: definition.valueDefinition::class.qualifiedName)
+            }
+            is IsMapDefinition<*, *, *> -> {
+                append(" key=")
+                append(definition.keyDefinition::class.simpleName ?: definition.keyDefinition::class.qualifiedName)
+                append(", value=")
+                append(definition.valueDefinition::class.simpleName ?: definition.valueDefinition::class.qualifiedName)
+            }
+        }
+    }
+
+    val lines = mutableListOf(details)
+    if (wrapper.definition is IsEmbeddedDefinition<*>) {
+        val nested = (wrapper.definition as IsEmbeddedDefinition<*>).dataModel
+        if (nested.iterator().hasNext()) {
+            for (child in nested) {
+                lines.addAll(describeProperty(child, "$indent    "))
+            }
+        } else {
+            lines += "$indent    <empty embedded model>"
+        }
+    }
+    return lines
+}

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/StoreConnectionConfig.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/StoreConnectionConfig.kt
@@ -1,0 +1,26 @@
+package maryk.datastore.terminal
+
+import com.apple.foundationdb.tuple.Tuple
+import maryk.datastore.terminal.driver.StoreType
+
+/**
+ * Connection information provided either through command line arguments or the interactive wizard.
+ */
+sealed interface StoreConnectionConfig {
+    val type: StoreType
+
+    data class RocksDb(
+        val path: String,
+    ) : StoreConnectionConfig {
+        override val type: StoreType = StoreType.RocksDb
+    }
+
+    data class FoundationDb(
+        val clusterFile: String?,
+        val tenant: Tuple?,
+        val directoryRoot: List<String>,
+        val apiVersion: Int,
+    ) : StoreConnectionConfig {
+        override val type: StoreType = StoreType.FoundationDb
+    }
+}

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalClient.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalClient.kt
@@ -1,0 +1,101 @@
+package maryk.datastore.terminal
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import com.apple.foundationdb.tuple.Tuple
+import com.jakewharton.mosaic.runMosaicMain
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import maryk.datastore.terminal.driver.StoreType
+
+fun main(args: Array<String>) {
+    val config = parseConnectionArgs(args)
+
+    runMosaicMain {
+        val scope = remember { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
+        val initialMode = remember(config) {
+            if (config != null) UiMode.Prompt(input = "") else UiMode.SelectStore(selectedIndex = 0)
+        }
+        val state = remember { TerminalState(initialMode) }
+        val controller = remember { TerminalController(scope, state) { scope.cancel() } }
+
+        DisposableEffect(Unit) {
+            onDispose { scope.cancel() }
+        }
+
+        LaunchedEffect(config) {
+            if (config != null) {
+                state.appendLog("Using connection parameters from command line arguments.")
+                controller.startWithConfig(config)
+            } else {
+                controller.beginWizard()
+            }
+        }
+
+        TerminalScreen(state, controller)
+    }
+}
+
+private fun parseConnectionArgs(args: Array<String>): StoreConnectionConfig? {
+    var storeType: StoreType? = null
+    var rocksPath: String? = null
+    var clusterFile: String? = null
+    var tenant: String? = null
+    var directoryRoot: String? = null
+    var apiVersion: Int? = null
+
+    for (arg in args) {
+        when {
+            arg.equals("--rocksdb", ignoreCase = true) -> storeType = StoreType.RocksDb
+            arg.equals("--foundationdb", ignoreCase = true) -> storeType = StoreType.FoundationDb
+            arg.startsWith("--store=", ignoreCase = true) -> {
+                storeType = when (arg.substringAfter('=').lowercase()) {
+                    "rocksdb" -> StoreType.RocksDb
+                    "foundationdb", "fdb" -> StoreType.FoundationDb
+                    else -> storeType
+                }
+            }
+            arg.startsWith("--rocksdb-path=", ignoreCase = true) -> {
+                rocksPath = arg.substringAfter('=').trim().takeIf { it.isNotEmpty() }
+                storeType = StoreType.RocksDb
+            }
+            arg.startsWith("--fdb-cluster=", ignoreCase = true) -> {
+                clusterFile = arg.substringAfter('=').trim().takeIf { it.isNotEmpty() }
+                storeType = StoreType.FoundationDb
+            }
+            arg.startsWith("--fdb-tenant=", ignoreCase = true) -> {
+                tenant = arg.substringAfter('=').trim().takeIf { it.isNotEmpty() }
+                storeType = StoreType.FoundationDb
+            }
+            arg.startsWith("--fdb-directory=", ignoreCase = true) -> {
+                directoryRoot = arg.substringAfter('=').trim().takeIf { it.isNotEmpty() }
+                storeType = StoreType.FoundationDb
+            }
+            arg.startsWith("--fdb-api-version=", ignoreCase = true) -> {
+                apiVersion = arg.substringAfter('=').trim().toIntOrNull()
+                storeType = StoreType.FoundationDb
+            }
+        }
+    }
+
+    return when (storeType) {
+        StoreType.RocksDb -> rocksPath?.let { StoreConnectionConfig.RocksDb(it) }
+        StoreType.FoundationDb -> {
+            val directories = directoryRoot?.split(Regex("[\\s,/]+"))
+                ?.map { it.trim() }
+                ?.filter { it.isNotEmpty() }
+                ?: emptyList()
+            val tuple = tenant?.let { Tuple.from(it) }
+            StoreConnectionConfig.FoundationDb(
+                clusterFile = clusterFile,
+                tenant = tuple,
+                directoryRoot = if (directories.isEmpty()) listOf("maryk") else directories,
+                apiVersion = apiVersion ?: 730,
+            )
+        }
+        null -> null
+    }
+}

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalClient.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalClient.kt
@@ -28,7 +28,12 @@ fun main(args: Array<String>) {
 
         LaunchedEffect(config) {
             if (config != null) {
-                state.appendLog("Using connection parameters from command line arguments.")
+                state.recordHistory(
+                    label = "startup",
+                    heading = "Command line configuration",
+                    lines = listOf("Using connection parameters from command line arguments."),
+                    style = PanelStyle.Info,
+                )
                 controller.startWithConfig(config)
             } else {
                 controller.beginWizard()

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalScreen.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalScreen.kt
@@ -35,6 +35,10 @@ fun TerminalScreen(
 
         Spacer(modifier = Modifier.height(1))
 
+        OutputView(state)
+
+        Spacer(modifier = Modifier.height(1))
+
         LogView(state)
 
         Spacer(modifier = Modifier.height(1))
@@ -65,15 +69,28 @@ private fun Header(state: TerminalState) {
 
 @Composable
 private fun LogView(state: TerminalState) {
-    val lines = if (state.logLines.size <= 14) {
-        state.logLines
-    } else {
-        state.logLines.takeLast(14)
-    }
+    val lines = if (state.logLines.size <= 12) state.logLines else state.logLines.takeLast(12)
+    Text("Logs:")
     if (lines.isEmpty()) {
-        Text("Logs will appear here after commands are executed.")
+        Text("  <none>")
     } else {
-        Text("Logs:")
+        lines.forEach { Text("  $it") }
+    }
+}
+
+@Composable
+private fun OutputView(state: TerminalState) {
+    val title = state.outputTitle.value
+    val lines = state.outputLines
+    if (title == null && lines.isEmpty()) {
+        Text("Output:")
+        Text("  <none>")
+        return
+    }
+    Text(title ?: "Output:")
+    if (lines.isEmpty()) {
+        Text("  <none>")
+    } else {
         lines.forEach { Text("  $it") }
     }
 }
@@ -105,7 +122,6 @@ private fun PromptView(mode: UiMode.Prompt) {
         Text("> ")
         Text(mode.input)
     }
-    Text("Commands: help, list, model, exit")
 }
 
 @Composable

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalScreen.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalScreen.kt
@@ -1,0 +1,122 @@
+package maryk.datastore.terminal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import com.jakewharton.mosaic.layout.height
+import com.jakewharton.mosaic.layout.onKeyEvent
+import com.jakewharton.mosaic.layout.padding
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.Column
+import com.jakewharton.mosaic.ui.Row
+import com.jakewharton.mosaic.ui.Spacer
+import com.jakewharton.mosaic.ui.Text
+import kotlinx.coroutines.awaitCancellation
+import maryk.datastore.terminal.driver.StoreType
+
+@Composable
+fun TerminalScreen(
+    state: TerminalState,
+    controller: TerminalController,
+) {
+    val mode by state.mode
+
+    DisposableEffect(Unit) {
+        onDispose { state.close() }
+    }
+
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 2, vertical = 1)
+            .onKeyEvent { controller.handleKey(it) },
+    ) {
+        Header(state)
+
+        Spacer(modifier = Modifier.height(1))
+
+        LogView(state)
+
+        Spacer(modifier = Modifier.height(1))
+
+        when (val currentMode = mode) {
+            is UiMode.SelectStore -> StoreSelectionView(currentMode)
+            is UiMode.ConfigureStore -> ConfigureStoreView(currentMode)
+            is UiMode.Prompt -> PromptView(currentMode)
+            is UiMode.ModelSelection -> ModelSelectionView(currentMode)
+        }
+    }
+
+    if (!state.shouldExit.value) {
+        LaunchedEffect(Unit) { awaitCancellation() }
+    }
+}
+
+@Composable
+private fun Header(state: TerminalState) {
+    Text("Maryk DataStore Terminal")
+    state.connectionDescription.value?.let {
+        Text("Connected: $it")
+    } ?: Text("No store connected. Use the wizard to configure a store.")
+    if (state.isConnecting.value) {
+        Text("Connecting...")
+    }
+}
+
+@Composable
+private fun LogView(state: TerminalState) {
+    val lines = if (state.logLines.size <= 14) {
+        state.logLines
+    } else {
+        state.logLines.takeLast(14)
+    }
+    if (lines.isEmpty()) {
+        Text("Logs will appear here after commands are executed.")
+    } else {
+        Text("Logs:")
+        lines.forEach { Text("  $it") }
+    }
+}
+
+@Composable
+private fun StoreSelectionView(mode: UiMode.SelectStore) {
+    Text("Select a store (↑/↓ then Enter):")
+    StoreType.entries.forEachIndexed { index, storeType ->
+        val prefix = if (index == mode.selectedIndex) "➤" else " "
+        Text("$prefix ${storeType.displayName}")
+    }
+    Text("Commands are available after selecting and connecting to a store.")
+}
+
+@Composable
+private fun ConfigureStoreView(mode: UiMode.ConfigureStore) {
+    val field = mode.currentField
+    Text("Configure ${mode.storeType.displayName} (${mode.fieldIndex + 1}/${mode.fields.size})")
+    Text(field.label)
+    field.description?.let { Text("  $it") }
+    field.defaultValue?.takeIf { it.isNotEmpty() }?.let { Text("  Default: $it") }
+    Text("  Input: ${mode.input}")
+    Text("Press Enter to confirm, Tab to accept default, or Esc to cancel.")
+}
+
+@Composable
+private fun PromptView(mode: UiMode.Prompt) {
+    Row {
+        Text("> ")
+        Text(mode.input)
+    }
+    Text("Commands: help, list, model, exit")
+}
+
+@Composable
+private fun ModelSelectionView(mode: UiMode.ModelSelection) {
+    if (mode.models.isEmpty()) {
+        Text("No models available.")
+        return
+    }
+    Text("Select a model (↑/↓, Enter, Esc to cancel):")
+    mode.models.forEachIndexed { index, model ->
+        val prefix = if (index == mode.selectedIndex) "➤" else " "
+        Text("$prefix ${model.name} (v${model.version})")
+    }
+}

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalState.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/TerminalState.kt
@@ -1,0 +1,487 @@
+package maryk.datastore.terminal
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import com.apple.foundationdb.tuple.Tuple
+import com.jakewharton.mosaic.layout.KeyEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import maryk.datastore.terminal.driver.StoredModel
+import maryk.datastore.terminal.driver.StoreDriver
+import maryk.datastore.terminal.driver.StoreType
+import maryk.datastore.terminal.driver.createStoreDriver
+import maryk.datastore.terminal.renderModelDefinition
+
+private const val MAX_LOG_LINES = 200
+
+/** A single field in the connection wizard. */
+data class StoreField(
+    val key: String,
+    val label: String,
+    val optional: Boolean = false,
+    val description: String? = null,
+    val defaultValue: String? = null,
+)
+
+sealed interface UiMode {
+    data class SelectStore(val selectedIndex: Int) : UiMode
+    data class ConfigureStore(
+        val storeType: StoreType,
+        val fields: List<StoreField>,
+        val fieldIndex: Int,
+        val values: Map<String, String?>,
+        val input: String,
+    ) : UiMode {
+        val currentField: StoreField get() = fields[fieldIndex]
+    }
+    data class Prompt(val input: String) : UiMode
+    data class ModelSelection(val models: List<StoredModel>, val selectedIndex: Int) : UiMode
+}
+
+class TerminalState(initialMode: UiMode) {
+    val mode = mutableStateOf(initialMode)
+    val logLines = mutableStateListOf<String>()
+    val isConnecting = mutableStateOf(false)
+    val connectionDescription = mutableStateOf<String?>(null)
+    val shouldExit = mutableStateOf(false)
+
+    private val models = mutableStateListOf<StoredModel>()
+    private val driver = mutableStateOf<StoreDriver?>(null)
+
+    fun updateMode(mode: UiMode) {
+        this.mode.value = mode
+    }
+
+    fun appendLog(line: String) {
+        if (logLines.size >= MAX_LOG_LINES) {
+            logLines.removeFirst()
+        }
+        logLines.add(line)
+    }
+
+    fun currentModels(): List<StoredModel> = models.toList()
+
+    fun setModels(newModels: List<StoredModel>) {
+        models.clear()
+        models.addAll(newModels)
+    }
+
+    fun driver(): StoreDriver? = driver.value
+
+    fun setDriver(driver: StoreDriver?) {
+        this.driver.value = driver
+    }
+
+    fun close() {
+        driver.value?.close()
+        models.clear()
+    }
+}
+
+class TerminalController(
+    private val scope: CoroutineScope,
+    private val state: TerminalState,
+    private val onExit: () -> Unit,
+) {
+    private val storeFields = mapOf(
+        StoreType.RocksDb to listOf(
+            StoreField(
+                key = "path",
+                label = "Path to RocksDB database directory",
+                description = "Provide the absolute or relative path to the RocksDB data directory.",
+            ),
+        ),
+        StoreType.FoundationDb to listOf(
+            StoreField(
+                key = "clusterFile",
+                label = "Cluster file path (optional)",
+                optional = true,
+                description = "Leave empty to use the default FDB configuration (env FDB_CLUSTER_FILE).",
+            ),
+            StoreField(
+                key = "tenant",
+                label = "Tenant name (optional)",
+                optional = true,
+                description = "Tenant tuple element, leave empty when not using tenants.",
+            ),
+            StoreField(
+                key = "directory",
+                label = "Directory root path",
+                description = "Comma or slash separated list (default maryk).",
+                defaultValue = "maryk",
+            ),
+            StoreField(
+                key = "apiVersion",
+                label = "API version",
+                description = "FoundationDB API version (default 730).",
+                defaultValue = "730",
+            ),
+        ),
+    )
+
+    private val helpEntries = mapOf(
+        "help" to "help [command] - Show commands or detailed help for a command.",
+        "list" to "list | l - List all models stored in the connected database.",
+        "model" to "model [name] - Display the stored model structure. Without name opens a selector.",
+        "exit" to "exit - Close the terminal client.",
+    )
+
+    fun startWithConfig(config: StoreConnectionConfig) {
+        state.updateMode(UiMode.Prompt(input = ""))
+        connect(config)
+    }
+
+    fun beginWizard() {
+        state.updateMode(UiMode.SelectStore(selectedIndex = 0))
+    }
+
+    fun handleKey(event: KeyEvent): Boolean = when (val mode = state.mode.value) {
+        is UiMode.SelectStore -> handleSelectStoreKey(mode, event)
+        is UiMode.ConfigureStore -> handleConfigureStoreKey(mode, event)
+        is UiMode.Prompt -> handlePromptKey(mode, event)
+        is UiMode.ModelSelection -> handleModelSelectionKey(mode, event)
+    }
+
+    private fun handleSelectStoreKey(mode: UiMode.SelectStore, event: KeyEvent): Boolean {
+        return when (event.key) {
+            "ArrowUp" -> {
+                val newIndex = (mode.selectedIndex - 1).coerceAtLeast(0)
+                state.updateMode(mode.copy(selectedIndex = newIndex))
+                true
+            }
+            "ArrowDown" -> {
+                val newIndex = (mode.selectedIndex + 1).coerceAtMost(StoreType.entries.lastIndex)
+                state.updateMode(mode.copy(selectedIndex = newIndex))
+                true
+            }
+            "Enter" -> {
+                val selectedType = StoreType.entries[mode.selectedIndex]
+                val fields = storeFields.getValue(selectedType)
+                val initialInput = fields.firstOrNull()?.defaultValue.orEmpty()
+                state.updateMode(
+                    UiMode.ConfigureStore(
+                        storeType = selectedType,
+                        fields = fields,
+                        fieldIndex = 0,
+                        values = emptyMap(),
+                        input = initialInput,
+                    ),
+                )
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun handleConfigureStoreKey(
+        mode: UiMode.ConfigureStore,
+        event: KeyEvent,
+    ): Boolean {
+        return when (event.key) {
+            "Backspace" -> {
+                if (mode.input.isNotEmpty()) {
+                    state.updateMode(mode.copy(input = mode.input.dropLast(1)))
+                }
+                true
+            }
+            "Escape" -> {
+                beginWizard()
+                true
+            }
+            "Enter" -> {
+                val rawValue = mode.input
+                val finalValue: String? = when {
+                    rawValue.isNotEmpty() -> rawValue
+                    !mode.currentField.defaultValue.isNullOrEmpty() -> mode.currentField.defaultValue
+                    mode.currentField.optional -> null
+                    else -> {
+                        state.appendLog("${mode.currentField.label} is required.")
+                        return true
+                    }
+                }
+                val updatedValues = mode.values.toMutableMap()
+                updatedValues[mode.currentField.key] = finalValue
+
+                if (mode.fieldIndex + 1 < mode.fields.size) {
+                    val nextField = mode.fields[mode.fieldIndex + 1]
+                    state.updateMode(
+                        mode.copy(
+                            fieldIndex = mode.fieldIndex + 1,
+                            values = updatedValues,
+                            input = nextField.defaultValue.orEmpty(),
+                        ),
+                    )
+                } else {
+                    buildConfig(mode.storeType, updatedValues)?.let { connect(it) }
+                }
+                true
+            }
+            "Tab" -> {
+                handleConfigureStoreKey(mode, KeyEvent("Enter"))
+            }
+            else -> {
+                val key = event.key
+                val character = when {
+                    key.length == 1 -> key
+                    key == "Space" -> " "
+                    else -> null
+                }
+                if (character != null) {
+                    state.updateMode(mode.copy(input = mode.input + character))
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    private fun handlePromptKey(mode: UiMode.Prompt, event: KeyEvent): Boolean {
+        return when (event.key) {
+            "Backspace" -> {
+                if (mode.input.isNotEmpty()) {
+                    state.updateMode(mode.copy(input = mode.input.dropLast(1)))
+                }
+                true
+            }
+            "Enter" -> {
+                val command = mode.input.trim()
+                state.updateMode(mode.copy(input = ""))
+                if (command.isNotEmpty()) {
+                    executeCommand(command)
+                }
+                true
+            }
+            else -> {
+                val key = event.key
+                val character = when {
+                    key.length == 1 -> key
+                    key == "Space" -> " "
+                    else -> null
+                }
+                if (character != null) {
+                    state.updateMode(mode.copy(input = mode.input + character))
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    private fun handleModelSelectionKey(
+        mode: UiMode.ModelSelection,
+        event: KeyEvent,
+    ): Boolean {
+        return when (event.key) {
+            "ArrowUp" -> {
+                val newIndex = (mode.selectedIndex - 1).coerceAtLeast(0)
+                state.updateMode(mode.copy(selectedIndex = newIndex))
+                true
+            }
+            "ArrowDown" -> {
+                val newIndex = (mode.selectedIndex + 1).coerceAtMost((mode.models.size - 1).coerceAtLeast(0))
+                state.updateMode(mode.copy(selectedIndex = newIndex))
+                true
+            }
+            "Enter" -> {
+                mode.models.getOrNull(mode.selectedIndex)?.let { model ->
+                    displayModel(model.name)
+                }
+                state.updateMode(UiMode.Prompt(input = ""))
+                true
+            }
+            "Escape" -> {
+                state.updateMode(UiMode.Prompt(input = ""))
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun executeCommand(command: String) {
+        val parts = command.split(Regex("\\s+"), limit = 2)
+        val action = parts.first().lowercase()
+        val argument = parts.getOrNull(1)?.trim().orEmpty()
+
+        if (state.isConnecting.value) {
+            state.appendLog("Connection in progress. Please wait...")
+            return
+        }
+
+        when (action) {
+            "help", "h" -> showHelp(argument)
+            "list", "l" -> listModels()
+            "model" -> {
+                if (argument.isNotEmpty()) {
+                    displayModel(argument)
+                } else {
+                    openModelSelector()
+                }
+            }
+            "exit" -> exit()
+            "connect" -> {
+                state.appendLog("Reconnect is not supported from the prompt. Restart the client to choose another store.")
+            }
+            else -> state.appendLog("Unknown command '$action'. Type 'help' to see available commands.")
+        }
+    }
+
+    private fun showHelp(argument: String) {
+        if (argument.isBlank()) {
+            state.appendLog("Available commands:")
+            helpEntries.values.forEach { state.appendLog("  $it") }
+        } else {
+            val key = argument.lowercase()
+            val match = helpEntries.entries.firstOrNull { (cmd, _) ->
+                cmd == key || cmd.startsWith(key)
+            }
+            if (match != null) {
+                state.appendLog(match.value)
+            } else {
+                state.appendLog("No help available for '$argument'.")
+            }
+        }
+    }
+
+    private fun listModels() {
+        val driver = state.driver()
+        if (driver == null) {
+            state.appendLog("No store connected. Complete the wizard first.")
+            return
+        }
+
+        scope.launch {
+            try {
+                val models = driver.listModels()
+                state.setModels(models)
+                if (models.isEmpty()) {
+                    state.appendLog("No models found in store.")
+                } else {
+                    state.appendLog("Models:")
+                    models.forEach { model ->
+                        state.appendLog("  • ${model.name} (v${model.version})")
+                    }
+                }
+            } catch (e: Exception) {
+                state.appendLog("Failed to list models: ${e.message}")
+            }
+        }
+    }
+
+    private fun openModelSelector() {
+        val driver = state.driver()
+        if (driver == null) {
+            state.appendLog("No store connected. Complete the wizard first.")
+            return
+        }
+
+        scope.launch {
+            try {
+                val models = if (state.currentModels().isEmpty()) driver.listModels() else state.currentModels()
+                if (models.isEmpty()) {
+                    state.appendLog("No models found in store.")
+                    state.updateMode(UiMode.Prompt(input = ""))
+                } else {
+                    state.setModels(models)
+                    state.updateMode(UiMode.ModelSelection(models.toList(), selectedIndex = 0))
+                }
+            } catch (e: Exception) {
+                state.appendLog("Failed to load models: ${e.message}")
+            }
+        }
+    }
+
+    private fun displayModel(name: String) {
+        val driver = state.driver()
+        if (driver == null) {
+            state.appendLog("No store connected. Complete the wizard first.")
+            return
+        }
+
+        scope.launch {
+            try {
+                val model = driver.loadModel(name)
+                if (model == null) {
+                    state.appendLog("Model '$name' not found.")
+                } else {
+                    val lines = renderModelDefinition(model)
+                    lines.forEach { state.appendLog(it) }
+                }
+            } catch (e: Exception) {
+                state.appendLog("Failed to load model '$name': ${e.message}")
+            }
+        }
+    }
+
+    private fun buildConfig(storeType: StoreType, values: Map<String, String?>): StoreConnectionConfig? = when (storeType) {
+        StoreType.RocksDb -> {
+            val path = values["path"]?.trim().orEmpty()
+            if (path.isBlank()) {
+                state.appendLog("RocksDB path is required.")
+                null
+            } else {
+                StoreConnectionConfig.RocksDb(path)
+            }
+        }
+        StoreType.FoundationDb -> {
+            val cluster = values["clusterFile"]?.trim().orEmpty().ifBlank { null }
+            val tenantValue = values["tenant"]?.trim().orEmpty().ifBlank { null }
+            val directoryRaw = values["directory"]?.trim().orEmpty().ifBlank { "maryk" }
+            val directories = directoryRaw.split(Regex("[\\s,/]+"))
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+            val apiVersion = values["apiVersion"]?.trim().orEmpty().ifBlank { "730" }.toIntOrNull()
+            if (apiVersion == null) {
+                state.appendLog("Invalid API version. Provide a numeric value.")
+                null
+            } else {
+                val tenant = tenantValue?.let { Tuple.from(it) }
+                StoreConnectionConfig.FoundationDb(
+                    clusterFile = cluster,
+                    tenant = tenant,
+                    directoryRoot = if (directories.isEmpty()) listOf("maryk") else directories,
+                    apiVersion = apiVersion,
+                )
+            }
+        }
+    }
+
+    private fun connect(config: StoreConnectionConfig) {
+        state.isConnecting.value = true
+        state.appendLog("Connecting to ${config.type.displayName}...")
+
+        scope.launch {
+            val driver = createStoreDriver(config)
+            runCatching {
+                driver.connect()
+            }.onSuccess {
+                state.driver()?.close()
+                state.setDriver(driver)
+                state.setModels(emptyList())
+                state.connectionDescription.value = driver.description
+                state.appendLog("Connected to ${driver.description}")
+                state.isConnecting.value = false
+                state.updateMode(UiMode.Prompt(input = ""))
+            }.onFailure { error ->
+                state.isConnecting.value = false
+                state.appendLog("Failed to connect: ${error.message}")
+                driver.close()
+                beginWizard()
+            }
+        }
+    }
+
+    private fun exit() {
+        state.appendLog("Closing terminal client.")
+        state.shouldExit.value = true
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                state.close()
+            }
+            onExit()
+        }
+    }
+}

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/DriverMetadataKeys.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/DriverMetadataKeys.kt
@@ -1,0 +1,6 @@
+package maryk.datastore.terminal.driver
+
+internal val MODEL_NAME_KEY = byteArrayOf(0)
+internal val MODEL_VERSION_KEY = byteArrayOf(1)
+internal val MODEL_DEFINITION_KEY = byteArrayOf(2)
+internal val MODEL_DEPENDENTS_KEY = byteArrayOf(3)

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/FoundationDbStoreDriver.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/FoundationDbStoreDriver.kt
@@ -1,0 +1,153 @@
+package maryk.datastore.terminal.driver
+
+import com.apple.foundationdb.FDB
+import com.apple.foundationdb.directory.DirectoryLayer
+import com.apple.foundationdb.directory.DirectorySubspace
+import com.apple.foundationdb.tuple.Tuple
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import maryk.core.definitions.Definitions
+import maryk.core.models.RootDataModel
+import maryk.core.properties.definitions.contextual.DataModelReference
+import maryk.core.properties.types.Version
+import maryk.core.query.DefinitionsConversionContext
+import maryk.datastore.terminal.StoreConnectionConfig
+
+private const val DEFAULT_API_VERSION = 730
+
+class FoundationDbStoreDriver(
+    private val config: StoreConnectionConfig.FoundationDb,
+) : StoreDriver {
+    override val type: StoreType = StoreType.FoundationDb
+
+    override val description: String = buildString {
+        append("FoundationDB")
+        config.clusterFile?.let { append(" [cluster=$it]") }
+        append(" root=")
+        append(config.directoryRoot.joinToString(separator = "/"))
+        config.tenant?.let { tenant ->
+            append(" tenant=")
+            append(renderTenant(tenant))
+        }
+    }
+
+    private val conversionContext = DefinitionsConversionContext()
+    private val modelsByName = linkedMapOf<String, StoredModel>()
+
+    private lateinit var fdb: FDB
+    private lateinit var database: com.apple.foundationdb.Database
+    private lateinit var rootDirectory: DirectorySubspace
+    private lateinit var rootPath: List<String>
+
+    private var initialized = false
+
+    override suspend fun connect() {
+        withContext(Dispatchers.IO) {
+            val apiVersion = config.apiVersion.takeIf { it > 0 } ?: DEFAULT_API_VERSION
+            fdb = FDB.selectAPIVersion(apiVersion)
+            database = if (config.clusterFile != null) {
+                fdb.open(config.clusterFile)
+            } else {
+                fdb.open()
+            }
+
+            rootPath = (if (config.directoryRoot.isEmpty()) listOf("maryk") else config.directoryRoot).toList()
+            rootDirectory = DirectoryLayer.getDefault().open(database, rootPath, null).join()
+        }
+        initialized = true
+    }
+
+    override suspend fun listModels(): List<StoredModel> = withContext(Dispatchers.IO) {
+        ensureInitialized()
+        if (modelsByName.isEmpty()) {
+            loadAllModels()
+        }
+        modelsByName.values.toList()
+    }
+
+    override suspend fun loadModel(name: String): StoredModel? = withContext(Dispatchers.IO) {
+        ensureInitialized()
+        if (modelsByName.isEmpty()) {
+            loadAllModels()
+        }
+        modelsByName[name]
+    }
+
+    private fun loadAllModels() {
+        modelsByName.clear()
+        val modelNames = DirectoryLayer.getDefault().list(database, rootPath).join()
+        val loaded = modelNames.mapNotNull { modelName ->
+            val metaPath = rootDirectory.path + listOf(modelName, "meta")
+            val metaDirectory = DirectoryLayer.getDefault().open(database, metaPath, null).join()
+            loadModelDefinition(modelName, metaDirectory)
+        }.sortedBy { it.name }
+
+        loaded.forEach { modelsByName[it.name] = it }
+    }
+
+    private fun loadModelDefinition(modelName: String, directory: DirectorySubspace): StoredModel? {
+        val prefix = directory.pack() ?: return null
+        val nameBytes = database.read { tr -> tr.get(prefix + MODEL_NAME_KEY).join() }
+        val versionBytes = database.read { tr -> tr.get(prefix + MODEL_VERSION_KEY).join() }
+        if (nameBytes == null || versionBytes == null) {
+            return null
+        }
+
+        database.read { tr ->
+            tr.get(prefix + MODEL_DEPENDENTS_KEY).join()
+        }?.let { dependentsBytes ->
+            var depIndex = 0
+            Definitions.Serializer.readProtoBuf(
+                dependentsBytes.size,
+                { dependentsBytes[depIndex++] },
+                conversionContext,
+            ).toDataObject()
+        }
+
+        val modelBytes = database.read { tr -> tr.get(prefix + MODEL_DEFINITION_KEY).join() } ?: return null
+        var modelIndex = 0
+        val storedModel = RootDataModel.Model.Serializer
+            .readProtoBuf(modelBytes.size, { modelBytes[modelIndex++] }, conversionContext)
+            .toDataObject()
+
+        conversionContext.dataModels[modelName] = DataModelReference(storedModel)
+
+        var versionIndex = 0
+        val version = Version.Serializer.readFromBytes { versionBytes[versionIndex++] }
+
+        return StoredModel(modelName, version, storedModel)
+    }
+
+    private fun ensureInitialized() {
+        if (!initialized) {
+            throw IOException("Driver is not connected. Call connect() first.")
+        }
+    }
+
+    override fun close() {
+        modelsByName.clear()
+        runCatching { database.close() }
+    }
+
+    companion object {
+        private fun renderTenant(tuple: Tuple): String = buildString {
+            append('[')
+            val iterator = tuple.iterator()
+            var first = true
+            while (iterator.hasNext()) {
+                if (!first) append(',')
+                append(iterator.next())
+                first = false
+            }
+            append(']')
+        }
+    }
+}
+
+private operator fun ByteArray.plus(other: ByteArray): ByteArray {
+    val result = ByteArray(this.size + other.size)
+    this.copyInto(result)
+    other.copyInto(result, destinationOffset = this.size)
+    return result
+}

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/RocksDbStoreDriver.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/RocksDbStoreDriver.kt
@@ -8,7 +8,7 @@ import maryk.core.models.RootDataModel
 import maryk.core.properties.definitions.contextual.DataModelReference
 import maryk.core.properties.types.Version
 import maryk.core.query.DefinitionsConversionContext
-import maryk.datastore.terminal.driver.StoreConnectionConfig.RocksDb
+import maryk.datastore.terminal.StoreConnectionConfig.RocksDb
 import org.rocksdb.ColumnFamilyDescriptor
 import org.rocksdb.ColumnFamilyHandle
 import org.rocksdb.DBOptions

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/RocksDbStoreDriver.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/RocksDbStoreDriver.kt
@@ -1,0 +1,153 @@
+package maryk.datastore.terminal.driver
+
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import maryk.core.definitions.Definitions
+import maryk.core.models.RootDataModel
+import maryk.core.properties.definitions.contextual.DataModelReference
+import maryk.core.properties.types.Version
+import maryk.core.query.DefinitionsConversionContext
+import maryk.datastore.terminal.driver.StoreConnectionConfig.RocksDb
+import org.rocksdb.ColumnFamilyDescriptor
+import org.rocksdb.ColumnFamilyHandle
+import org.rocksdb.DBOptions
+import org.rocksdb.Options
+import org.rocksdb.RocksDB
+
+private const val MODEL_TABLE_PREFIX: Byte = 1
+
+private data class ModelColumnFamily(
+    val tableIndex: UInt,
+    val handle: ColumnFamilyHandle,
+)
+
+class RocksDbStoreDriver(
+    private val config: RocksDb,
+) : StoreDriver {
+    override val type: StoreType = StoreType.RocksDb
+
+    override val description: String = "RocksDB [path=${config.path}]"
+
+    private val conversionContext = DefinitionsConversionContext()
+    private val modelsByName = linkedMapOf<String, StoredModel>()
+
+    private lateinit var db: RocksDB
+    private lateinit var handles: MutableList<ColumnFamilyHandle>
+    private lateinit var modelColumnFamilies: List<ModelColumnFamily>
+    private var dbOptions: DBOptions? = null
+    private var initialized = false
+
+    override suspend fun connect() {
+        withContext(Dispatchers.IO) {
+            RocksDB.loadLibrary()
+            Options().use { options ->
+                val columnFamilyNames = RocksDB.listColumnFamilies(options, config.path)
+                if (columnFamilyNames.isEmpty()) {
+                    throw IOException("No column families found in RocksDB at ${config.path}")
+                }
+
+                val descriptors = columnFamilyNames.map { ColumnFamilyDescriptor(it) }
+                handles = mutableListOf()
+                val optionsForDb = DBOptions().setCreateIfMissing(false)
+                dbOptions = optionsForDb
+                db = RocksDB.openReadOnly(optionsForDb, config.path, descriptors, handles)
+                modelColumnFamilies = descriptors.zip(handles)
+                    .mapNotNull { (descriptor, handle) ->
+                        parseModelDescriptor(descriptor.name, handle)
+                    }
+            }
+        }
+        initialized = true
+    }
+
+    override suspend fun listModels(): List<StoredModel> = withContext(Dispatchers.IO) {
+        ensureInitialized()
+        if (modelsByName.isEmpty()) {
+            loadAllModels()
+        }
+        modelsByName.values.toList()
+    }
+
+    override suspend fun loadModel(name: String): StoredModel? = withContext(Dispatchers.IO) {
+        ensureInitialized()
+        if (modelsByName.isEmpty()) {
+            loadAllModels()
+        }
+        modelsByName[name]
+    }
+
+    private fun parseModelDescriptor(name: ByteArray, handle: ColumnFamilyHandle): ModelColumnFamily? {
+        if (name.isEmpty() || name[0] != MODEL_TABLE_PREFIX) {
+            return null
+        }
+        val index = parseVarUInt(name, start = 1)
+        return ModelColumnFamily(index, handle)
+    }
+
+    private fun parseVarUInt(bytes: ByteArray, start: Int): UInt {
+        var shift = 0
+        var result = 0u
+        var index = start
+        while (index < bytes.size) {
+            val value = bytes[index].toInt() and 0xFF
+            result = result or (((value and 0x7F).toUInt()) shl shift)
+            if (value and 0x80 == 0) {
+                return result
+            }
+            shift += 7
+            index++
+        }
+        throw IOException("Malformed table index in column family name")
+    }
+
+    private fun loadAllModels() {
+        modelsByName.clear()
+        val loaded = modelColumnFamilies.mapNotNull { loadModelDefinition(it) }
+            .sortedBy { it.name }
+        loaded.forEach { modelsByName[it.name] = it }
+    }
+
+    private fun loadModelDefinition(entry: ModelColumnFamily): StoredModel? {
+        val nameBytes = db.get(entry.handle, MODEL_NAME_KEY) ?: return null
+        val versionBytes = db.get(entry.handle, MODEL_VERSION_KEY) ?: return null
+
+        val name = nameBytes.decodeToString()
+        var versionIndex = 0
+        val version = Version.Serializer.readFromBytes { versionBytes[versionIndex++] }
+
+        db.get(entry.handle, MODEL_DEPENDENTS_KEY)?.let { dependentBytes ->
+            var depIndex = 0
+            Definitions.Serializer
+                .readProtoBuf(dependentBytes.size, { dependentBytes[depIndex++] }, conversionContext)
+                .toDataObject()
+        }
+
+        val modelBytes = db.get(entry.handle, MODEL_DEFINITION_KEY) ?: return null
+        var modelIndex = 0
+        val storedModel = RootDataModel.Model.Serializer
+            .readProtoBuf(modelBytes.size, { modelBytes[modelIndex++] }, conversionContext)
+            .toDataObject()
+
+        conversionContext.dataModels[name] = DataModelReference(storedModel)
+
+        return StoredModel(name, version, storedModel)
+    }
+
+    private fun ensureInitialized() {
+        if (!initialized) {
+            throw IOException("Driver is not connected. Call connect() first.")
+        }
+    }
+
+    override fun close() {
+        modelsByName.clear()
+        if (this::handles.isInitialized) {
+            handles.forEach { handle ->
+                runCatching { handle.close() }
+            }
+        }
+        runCatching { db.close() }
+        runCatching { dbOptions?.close() }
+    }
+}

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StorageDecoders.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StorageDecoders.kt
@@ -1,0 +1,71 @@
+package maryk.datastore.terminal.driver
+
+import maryk.core.extensions.bytes.initIntByVar
+import maryk.core.models.RootDataModel
+import maryk.core.models.emptyValues
+import maryk.core.processors.datastore.StorageTypeEnum
+import maryk.core.processors.datastore.StorageTypeEnum.Embed
+import maryk.core.processors.datastore.StorageTypeEnum.ListSize
+import maryk.core.processors.datastore.StorageTypeEnum.MapSize
+import maryk.core.processors.datastore.StorageTypeEnum.ObjectDelete
+import maryk.core.processors.datastore.StorageTypeEnum.SetSize
+import maryk.core.processors.datastore.StorageTypeEnum.Value
+import maryk.core.processors.datastore.readStorageToValues
+import maryk.core.properties.definitions.wrapper.IsDefinitionWrapper
+import maryk.core.properties.references.IsPropertyReferenceForCache
+import maryk.core.values.Values
+import maryk.datastore.shared.readValue
+
+internal data class StorageEntry(
+    val qualifier: ByteArray,
+    val valueBytes: ByteArray,
+    val valueOffset: Int,
+)
+
+internal fun RootDataModel<*>.decodeStorageEntries(entries: List<StorageEntry>): Values<*> {
+    if (entries.isEmpty()) {
+        return this.emptyValues()
+    }
+
+    var currentEntry: StorageEntry = entries.first()
+    val iterator = entries.iterator()
+
+    return this.readStorageToValues(
+        getQualifier = { handler ->
+            if (!iterator.hasNext()) {
+                false
+            } else {
+                currentEntry = iterator.next()
+                val qualifier = currentEntry.qualifier
+                handler({ index -> qualifier[index] }, qualifier.size)
+                true
+            }
+        },
+        select = null,
+        processValue = { storageType, reference ->
+            decodeValueFromEntry(currentEntry, storageType, reference)
+        },
+    )
+}
+
+private fun decodeValueFromEntry(
+    entry: StorageEntry,
+    storageType: StorageTypeEnum<*>,
+    reference: IsPropertyReferenceForCache<*, *>,
+): Any? {
+    val bytes = entry.valueBytes
+    var index = entry.valueOffset
+
+    return when (storageType) {
+        ObjectDelete -> null
+        ListSize, SetSize, MapSize -> initIntByVar { bytes[index++] }
+        Embed -> null
+        Value -> {
+            val definition = (reference.propertyDefinition as? IsDefinitionWrapper<*, *, *, *>)?.definition
+                ?: reference.propertyDefinition
+            readValue(definition, { bytes[index++] }) { bytes.size - index }
+        }
+        else -> null
+    }
+}
+

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StoreDriver.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StoreDriver.kt
@@ -2,6 +2,7 @@ package maryk.datastore.terminal.driver
 
 import maryk.core.models.RootDataModel
 import maryk.core.properties.types.Version
+import maryk.core.values.Values
 
 /**
  * Enum describing the supported backing stores that the terminal client can connect to.
@@ -20,8 +21,13 @@ data class StoredModel(
     val definition: RootDataModel<*>,
 )
 
-data class ScanKeysResult(
-    val keys: List<ByteArray>,
+data class ScanRecord(
+    val key: ByteArray,
+    val values: Values<*>,
+)
+
+data class ScanResult(
+    val records: List<ScanRecord>,
     val nextStartAfterKey: ByteArray?,
 )
 
@@ -43,11 +49,11 @@ interface StoreDriver : AutoCloseable {
     /** Load a single model by name. */
     suspend fun loadModel(name: String): StoredModel?
 
-    /** Scan keys for a model returning up to [limit] keys starting after [startAfterKey]. */
-    suspend fun scanKeys(
+    /** Scan records for a model returning up to [limit] results starting after [startAfterKey]. */
+    suspend fun scanRecords(
         name: String,
         startAfterKey: ByteArray? = null,
         descending: Boolean = false,
         limit: Int = 100,
-    ): ScanKeysResult
+    ): ScanResult
 }

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StoreDriver.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StoreDriver.kt
@@ -20,6 +20,11 @@ data class StoredModel(
     val definition: RootDataModel<*>,
 )
 
+data class ScanKeysResult(
+    val keys: List<ByteArray>,
+    val nextStartAfterKey: ByteArray?,
+)
+
 /**
  * Common contract for store specific drivers that can be queried by the terminal client.
  */
@@ -37,4 +42,12 @@ interface StoreDriver : AutoCloseable {
 
     /** Load a single model by name. */
     suspend fun loadModel(name: String): StoredModel?
+
+    /** Scan keys for a model returning up to [limit] keys starting after [startAfterKey]. */
+    suspend fun scanKeys(
+        name: String,
+        startAfterKey: ByteArray? = null,
+        descending: Boolean = false,
+        limit: Int = 100,
+    ): ScanKeysResult
 }

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StoreDriver.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StoreDriver.kt
@@ -1,0 +1,40 @@
+package maryk.datastore.terminal.driver
+
+import maryk.core.models.RootDataModel
+import maryk.core.properties.types.Version
+
+/**
+ * Enum describing the supported backing stores that the terminal client can connect to.
+ */
+enum class StoreType(val displayName: String) {
+    RocksDb("RocksDB"),
+    FoundationDb("FoundationDB"),
+}
+
+/**
+ * Description of a stored model as retrieved from the data store metadata.
+ */
+data class StoredModel(
+    val name: String,
+    val version: Version,
+    val definition: RootDataModel<*>,
+)
+
+/**
+ * Common contract for store specific drivers that can be queried by the terminal client.
+ */
+interface StoreDriver : AutoCloseable {
+    val type: StoreType
+
+    /** Human readable description of the connection, shown in the UI header. */
+    val description: String
+
+    /** Establish the connection to the backing store and prepare metadata access. */
+    suspend fun connect()
+
+    /** Retrieve the complete list of stored models. */
+    suspend fun listModels(): List<StoredModel>
+
+    /** Load a single model by name. */
+    suspend fun loadModel(name: String): StoredModel?
+}

--- a/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StoreDriverFactory.kt
+++ b/store/terminal/src/main/kotlin/maryk/datastore/terminal/driver/StoreDriverFactory.kt
@@ -1,0 +1,11 @@
+package maryk.datastore.terminal.driver
+
+import maryk.datastore.terminal.StoreConnectionConfig
+
+/**
+ * Create a [StoreDriver] for the provided [config].
+ */
+fun createStoreDriver(config: StoreConnectionConfig): StoreDriver = when (config) {
+    is StoreConnectionConfig.RocksDb -> RocksDbStoreDriver(config)
+    is StoreConnectionConfig.FoundationDb -> FoundationDbStoreDriver(config)
+}

--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,14 @@ version.kotlinx.dataframe=0.15.0
 
 version.org.foundationdb..fdb-java=7.3.71
 
+version.com.jakewharton.mosaic..mosaic-runtime=0.17.0
+
+version.org.jetbrains.compose.runtime..runtime=1.7.3
+
+version.org.jetbrains.androidx.lifecycle..lifecycle-runtime-compose=2.8.4
+
+version.org.rocksdb..rocksdbjni=9.7.4
+
 version.org.jetbrains.kotlinx..atomicfu=0.29.0
 
 version.io.maryk.rocksdb..rocksdb-multiplatform-jvm=10.4.6

--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ version.kotlinx.dataframe=0.15.0
 
 version.org.foundationdb..fdb-java=7.3.71
 
-version.com.jakewharton.mosaic..mosaic-runtime=0.17.0
+version.com.jakewharton.mosaic..mosaic-runtime=0.18.0
 
 version.org.jetbrains.compose.runtime..runtime=1.7.3
 


### PR DESCRIPTION
## Summary
- update the terminal model renderer to flatten nested property output and align definition typing
- switch the RocksDB driver to the org.rocksdb APIs and load column families with descriptor.name

## Testing
- ./gradlew :store:terminal:compileKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e35a67e7cc83218d00413837615b70