### PR TITLE
Prevent cancellation from stopping FoundationDB actor

### DIFF
--- a/store/foundationdb/src/commonMain/kotlin/maryk/datastore/foundationdb/FoundationDBDataStore.kt
+++ b/store/foundationdb/src/commonMain/kotlin/maryk/datastore/foundationdb/FoundationDBDataStore.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.isActive
 import maryk.core.clock.HLC
 import maryk.core.exceptions.DefNotFoundException
 import maryk.core.exceptions.RequestException
@@ -284,7 +285,9 @@ class FoundationDBDataStore private constructor(
                         }
                     } catch (e: CancellationException) {
                         storeAction.response.cancel(e)
-                        throw e
+                        if (!isActive) {
+                            throw e
+                        }
                     } catch (e: Throwable) {
                         storeAction.response.completeExceptionally(e)
                     }


### PR DESCRIPTION
## Summary
- keep the FoundationDB store actor alive when a single request is cancelled
- only allow cancellation to stop the actor when the coroutine scope itself is no longer active

## Testing
- not run (FoundationDB service not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f6927ee50883219433aa8b5b972710